### PR TITLE
Develop

### DIFF
--- a/R/catmaid_connection.R
+++ b/R/catmaid_connection.R
@@ -131,8 +131,6 @@
 #' }
 #' @export
 #' 
-#' @examples
-#' conn=catmaid_login()
 catmaid_login<-function(conn=NULL, ..., Cache=TRUE, Force=FALSE){
   if(is.character(conn) && grepl("^http", conn)) {
     # this looks like a server, probably because we are trying to connect to 
@@ -445,7 +443,7 @@ catmaid_connection_fingerprint<-function(conn) {
 #' @seealso \code{\link{catmaid_login}}
 #' @export
 catmaid_connection_setenv<-function(conn=NULL, ...) {
-  if (is.null(conn)){conn=catmaid_login(conn, ...)} #only do the connection if I supply a null..
+  conn=catmaid_login(conn, ...)
   poss_vars_to_export=c("server", "username", "password", 
                         "authname", "authpassword", "authtype", "token")
   vars_to_export=intersect(poss_vars_to_export, names(conn))
@@ -546,14 +544,14 @@ catmaid_envstr <- function(){
   matchvalues <- grep(pattern = tempstr, x = names(Sys.getenv()), value = TRUE)
   
   if (length(grep(pattern = paste0("^", "catmaid", "\\.") , x= matchvalues)) == 4) {
-    return(paste0("catmaid."))
+    return("catmaid.")
   } else if (length(grep(pattern = paste0("^", "catmaid", "_") , x= matchvalues)) == 4) {
-    return(paste0("catmaid_"))
+    return("catmaid_")
   }else if (length(grep(pattern = paste0("^", "catmaid", "\\.") , x= matchvalues)) == 0 && 
             length(grep(pattern = paste0("^", "catmaid", "_") , x= matchvalues)) == 0) {
-    stop(paste("\ncatmaid error: No usable environmental variables found"))
+    simpleMessage("catmaid message: No usable environmental variables found")
   } 
-  else stop(paste("\ncatmaid error: Only found the following environmental variables -- ", matchvalues))
+  else stop(paste("\ncatmaid error: Only found the environmental variable -- ", matchvalues))
   
   
 }

--- a/R/catmaid_connection.R
+++ b/R/catmaid_connection.R
@@ -4,7 +4,7 @@
 #'   specified by a \code{catmaid_connection} object. If such an object is not 
 #'   specified, then the last successful connection in this R session is reused 
 #'   if possible otherwise a new connection object is created using 
-#'   \code{options} of the form "catmaid.*" (see details).
+#'   \code{options} of the form "catmaid.\*" or "catmaid_\*" (see details).
 #'   
 #'   The connection object returned by \code{catmaid_login} (or cached when 
 #'   \code{Cache=TRUE}, the default) can then be used for future requests to the
@@ -22,8 +22,8 @@
 #'   authentication as the strongly preferred alternative to specifying you
 #'   CATMAID username and password. See
 #'   \url{http://catmaid.github.io/dev/api.html#api-token} for how to get an API
-#'   token. You can then set the \code{catmaid.token} package option, but no
-#'   longer need to set the \code{catmaid.username} and \code{catmaid.password}
+#'   token. You can then set the \code{catmaid.token} or \code{catmaid_token} package option, but no
+#'   longer need to set the \code{catmaid.username} or \code{catmaid_username} and \code{catmaid.password} or \code{catmaid_password}
 #'   options.
 #'   
 #'   Note that you must \bold{NOT} reveal this token e.g. by checking it into a 
@@ -53,23 +53,24 @@
 #'   
 #'   \itemize{
 #'   
-#'   \item{\code{catmaid.server}}
+#'   \item{\code{catmaid.server} or \code{catmaid_server}}
 #'   
-#'   \item{\code{catmaid.token}} Preferred to using catmaid.username/password
+#'   \item{\code{catmaid.token} or \code{catmaid_token}} Preferred to using catmaid.username/password
 #'   
-#'   \item{\code{catmaid.authname}} Optional username for basic http website 
+#'   \item{\code{catmaid.authname} or \code{catmaid_authname}} Optional username for basic http website 
 #'   authorisation
 #'   
-#'   \item{\code{catmaid.authpassword}} Optional password for basic http website
+#'   \item{\code{catmaid.authpassword} or \code{catmaid_authpassword}} Optional password for basic http website
 #'   authorisation
 #'
-#'   \item{\code{catmaid.username}} Your catmaid username (deprecated in favour 
+#'   \item{\code{catmaid.username} or \code{catmaid_username}} Your catmaid username (deprecated in favour 
 #'   of token)
 #'   
-#'   \item{\code{catmaid.password}} Your catmaid password (deprecated in favour 
+#'   \item{\code{catmaid.password} or \code{catmaid_password}} Your catmaid password (deprecated in favour 
 #'   of token)
 #'   
-#'   } An example \code{.Renviron} file might look like:
+#'   } An example \code{.Renviron} file might look like (the periods(.) in the environmental variable name can be also replaced
+#'   with underscore(_) as mentioned above:
 #'   
 #'   \preformatted{
 #'catmaid.server="https://mycatmaidserver.org/catmaidroot"
@@ -129,6 +130,9 @@
 #'   config=conn$config)
 #' }
 #' @export
+#' 
+#' @examples
+#' conn=catmaid_login()
 catmaid_login<-function(conn=NULL, ..., Cache=TRUE, Force=FALSE){
   if(is.character(conn) && grepl("^http", conn)) {
     # this looks like a server, probably because we are trying to connect to 
@@ -271,8 +275,8 @@ catmaid_connection<-function(server, username=NULL, password=NULL, authname=NULL
   invisible(conn)
 }
 
-getenvoroption <- function(vars, prefix="catmaid."){
-  fullvars=paste0(prefix, vars)
+getenvoroption <- function(vars){
+  fullvars=paste0(catmaid_envstr(), vars)
   res=Sys.getenv(fullvars, names = T, unset = NA)
   if(all(is.na(res))){
     # no env variables are set, let's try options
@@ -441,12 +445,12 @@ catmaid_connection_fingerprint<-function(conn) {
 #' @seealso \code{\link{catmaid_login}}
 #' @export
 catmaid_connection_setenv<-function(conn=NULL, ...) {
-  conn=catmaid_login(conn, ...)
+  if (is.null(conn)){conn=catmaid_login(conn, ...)} #only do the connection if I supply a null..
   poss_vars_to_export=c("server", "username", "password", 
                         "authname", "authpassword", "authtype", "token")
   vars_to_export=intersect(poss_vars_to_export, names(conn))
   export_vector=unlist(conn[vars_to_export])
-  names(export_vector)=paste0("catmaid.",  names(export_vector))
+  names(export_vector)=paste0(catmaid_envstr(),  names(export_vector))
   all(do.call(Sys.setenv, as.list(export_vector)))
 }
 
@@ -458,19 +462,19 @@ catmaid_connection_setenv<-function(conn=NULL, ...) {
 catmaid_connection_getenv<-function() {
   varnames=c("server", "username", "password", 
              "authname", "authpassword", "authtype", "token")
-  catmaid_envnames=paste0("catmaid.", varnames)
+  catmaid_envnames=paste0(catmaid_envstr(), varnames)
   catmaid_envs=Sys.getenv(catmaid_envnames, unset = NA_character_)
   names(catmaid_envs)=varnames
   # drop any empty vars
   catmaid_envs=na.omit(catmaid_envs)
 }
 
-#' @description \code{catmaid_connection_unsetenv} unsets the environment
+#' @description \code{catmaid_connection_unsetenv} unsets (or removes) the environment
 #'   variables.
 #' @rdname catmaid_connection_setenv
 #' @export
 catmaid_connection_unsetenv<-function(){
-  vars=paste0("catmaid.",
+  vars=paste0(catmaid_envstr(),
               c("server", "username", "password", "authname", 
                 "authpassword", "authtype", "token"))
   Sys.unsetenv(vars)
@@ -534,3 +538,23 @@ set_catmaid_version <- function(version, conn=NULL, ...) {
   conn$catmaid.version=version
   catmaid_cache_connection(conn)
 }
+
+#This local function returns the string to be used in matching the environmental variable..
+# either catmaid_ or catmaid.
+catmaid_envstr <- function(){
+  tempstr <- paste0("^", "catmaid", "(\\.|_)") #searching for strings beginning with catmaid_ or catmaid.
+  matchvalues <- grep(pattern = tempstr, x = names(Sys.getenv()), value = TRUE)
+  
+  if (length(grep(pattern = paste0("^", "catmaid", "\\.") , x= matchvalues)) == 4) {
+    return(paste0("catmaid."))
+  } else if (length(grep(pattern = paste0("^", "catmaid", "_") , x= matchvalues)) == 4) {
+    return(paste0("catmaid_"))
+  }else if (length(grep(pattern = paste0("^", "catmaid", "\\.") , x= matchvalues)) == 0 && 
+            length(grep(pattern = paste0("^", "catmaid", "_") , x= matchvalues)) == 0) {
+    stop(paste("\ncatmaid error: No usable environmental variables found"))
+  } 
+  else stop(paste("\ncatmaid error: Only found the following environmental variables -- ", matchvalues))
+  
+  
+}
+

--- a/man/catmaid_connection_setenv.Rd
+++ b/man/catmaid_connection_setenv.Rd
@@ -30,7 +30,7 @@ implies that the most recent cached open connection will be used.}
 #' \code{catmaid_connection_getenv} fetches appropriately named
   environment variables and returns them as named character vector.
 
-\code{catmaid_connection_unsetenv} unsets the environment
+\code{catmaid_connection_unsetenv} unsets (or removes) the environment
   variables.
 }
 \details{

--- a/man/catmaid_login.Rd
+++ b/man/catmaid_login.Rd
@@ -49,7 +49,7 @@ a \code{catmaid_connection} object that can be used to make
   specified by a \code{catmaid_connection} object. If such an object is not 
   specified, then the last successful connection in this R session is reused 
   if possible otherwise a new connection object is created using 
-  \code{options} of the form "catmaid.*" (see details).
+  \code{options} of the form "catmaid.\*" or "catmaid_\*" (see details).
   
   The connection object returned by \code{catmaid_login} (or cached when 
   \code{Cache=TRUE}, the default) can then be used for future requests to the
@@ -82,8 +82,8 @@ Note the difference between \code{authname}/\code{authpassword} and
   authentication as the strongly preferred alternative to specifying you
   CATMAID username and password. See
   \url{http://catmaid.github.io/dev/api.html#api-token} for how to get an API
-  token. You can then set the \code{catmaid.token} package option, but no
-  longer need to set the \code{catmaid.username} and \code{catmaid.password}
+  token. You can then set the \code{catmaid.token} or \code{catmaid_token} package option, but no
+  longer need to set the \code{catmaid.username} or \code{catmaid_username} and \code{catmaid.password} or \code{catmaid_password}
   options.
   
   Note that you must \bold{NOT} reveal this token e.g. by checking it into a 
@@ -104,23 +104,24 @@ Note the difference between \code{authname}/\code{authpassword} and
   
   \itemize{
   
-  \item{\code{catmaid.server}}
+  \item{\code{catmaid.server} or \code{catmaid_server}}
   
-  \item{\code{catmaid.token}} Preferred to using catmaid.username/password
+  \item{\code{catmaid.token} or \code{catmaid_token}} Preferred to using catmaid.username/password
   
-  \item{\code{catmaid.authname}} Optional username for basic http website 
+  \item{\code{catmaid.authname} or \code{catmaid_authname}} Optional username for basic http website 
   authorisation
   
-  \item{\code{catmaid.authpassword}} Optional password for basic http website
+  \item{\code{catmaid.authpassword} or \code{catmaid_authpassword}} Optional password for basic http website
   authorisation
 
-  \item{\code{catmaid.username}} Your catmaid username (deprecated in favour 
+  \item{\code{catmaid.username} or \code{catmaid_username}} Your catmaid username (deprecated in favour 
   of token)
   
-  \item{\code{catmaid.password}} Your catmaid password (deprecated in favour 
+  \item{\code{catmaid.password} or \code{catmaid_password}} Your catmaid password (deprecated in favour 
   of token)
   
-  } An example \code{.Renviron} file might look like:
+  } An example \code{.Renviron} file might look like (the periods(.) in the environmental variable name can be also replaced
+  with underscore(_) as mentioned above:
   
   \preformatted{
 catmaid.server="https://mycatmaidserver.org/catmaidroot"
@@ -181,6 +182,7 @@ skel=catmaid_fetch("1/10418394/0/0/compact-skeleton")
 skel2=GET("https://mycatmaidserver.org/catmaidroot/1/10418394/0/0/compact-skeleton",
   config=conn$config)
 }
+conn=catmaid_login()
 }
 \seealso{
 \code{\link{options}}, \code{\link{Startup}}

--- a/man/catmaid_login.Rd
+++ b/man/catmaid_login.Rd
@@ -182,7 +182,6 @@ skel=catmaid_fetch("1/10418394/0/0/compact-skeleton")
 skel2=GET("https://mycatmaidserver.org/catmaidroot/1/10418394/0/0/compact-skeleton",
   config=conn$config)
 }
-conn=catmaid_login()
 }
 \seealso{
 \code{\link{options}}, \code{\link{Startup}}

--- a/tests/testthat/test-connections.R
+++ b/tests/testthat/test-connections.R
@@ -1,5 +1,27 @@
 context("catmaid login and get/post")
 
+test_that("set and get the environmental variables responsible for connections", {
+  #check the named object has all necessary fields..
+  expect_named(catmaid_connection_getenv(), c("server", "authname", "authpassword","token"))
+  #check if it returns a specific authname..
+  expect_match(catmaid_connection_getenv()['authname'],'fly')
+  #set a specific server name and check if it returns it back..
+  
+  
+  #Set environmental variables through connection object and check them back again..
+  conn <- catmaid_connection(server='http://somewhere.org', authname = "flyeee")
+  catmaid_connection_setenv(conn = conn)
+  expect_match(catmaid_connection_getenv()['server'],'http://somewhere.org')
+  expect_match(catmaid_connection_getenv()['authname'],'flyeee')
+  
+  #just unset them so the other test cases can run..
+  conn['authname'] <- "fly"
+  catmaid_connection_setenv(conn = conn)
+  expect_match(catmaid_connection_getenv()['authname'],'fly')
+
+  
+})
+
 test_that("can connect to a server without logging in", {
   # No login is required to talk to this server
   expect_is(catmaid_login(server='http://hildebrand16.neurodata.io/catmaid/', Cache = FALSE),
@@ -27,6 +49,9 @@ test_that("can make a connection from list elements", {
 })
 
 test_that("can login", {
+  #Just restart the connection here to a public server..
+  conn <- catmaid_login(server='http://hildebrand16.neurodata.io/catmaid/', Cache = FALSE)
+  
   if(inherits(conn, 'try-error')) skip('No catmaid connection')
   expect_is(conn, 'catmaid_connection')
   expect_is(conn$authresponse, 'response')
@@ -34,14 +59,22 @@ test_that("can login", {
 })
 
 test_that("can get and post data", {
+  
+  #Just restart the connection here to a public server..
+  conn <- catmaid_login(server='http://hildebrand16.neurodata.io/catmaid/', Cache = FALSE)
   if(inherits(conn, 'try-error')) skip('No catmaid connection')
-  expect_is(skel<-catmaid_fetch("1/10418394/0/0/compact-skeleton", conn=conn, parse.json = FALSE),
+ 
+  #Fetch the skeletons first..
+  expect_is(skel<-catmaid_fetch("2/skeletons", conn=conn, parse.json = FALSE),
             'response')
-  expect_is(neuronnames<-catmaid_fetch("/1/skeleton/neuronnames", conn=conn,
-                                  body=list(pid=1, 'skids[1]'=10418394, 'skids[2]'=4453485)),
+  
+  #Get the neuronnames from some skids..
+  skel_parsed<-catmaid_fetch("2/skeletons", conn=conn, parse.json = TRUE)
+  expect_is(neuronnames<-catmaid_fetch("/2/skeleton/neuronnames", conn=conn,
+                                       body=list(pid=2, 'skids[1]'=skel_parsed[[1]], 'skids[2]'=skel_parsed[[7]])),
             'list')
   # nb we can't rely on the returned order
-  expect_equal(sort(names(neuronnames)), c('10418394','4453485'))
+  expect_equal(sort(names(neuronnames)), c(as.character(skel_parsed[[1]]),as.character(skel_parsed[[7]])))
   expect_equal(names(attributes(neuronnames)), c("names", "url", "headers"))
 })
 


### PR DESCRIPTION
Updated for the issue #110. The relevant commits have the specific comments. To summarise this fixes the issue of environmental variables not working in linux machines (when using the check command in R). Also I fixed the test cases in tests/testthat/test-connections.R to point to a public server and added test cases for the set and get env vars. However I have not added any tests cases for the unset category as I'm not sure the need for that function itself.